### PR TITLE
Implimentation of auto brightness

### DIFF
--- a/__mocks/mocks.ts
+++ b/__mocks/mocks.ts
@@ -1,9 +1,8 @@
-import * as Simple from "run_simple";
 import { spy } from "jsr:@std/testing/mock";
 
 export const mockRun = spy(
   async (
-    command: string | Simple.SimpleValue[],
-    _options?: Simple.RunOptions,
-  ) => await (command as string[]).join(""),
+    cmd1: string[],
+    cmd2?: string[],
+  ) => await [...cmd1, ...(cmd2 ?? [])].join(""),
 );

--- a/deno.json
+++ b/deno.json
@@ -7,6 +7,7 @@
     "build": "deno compile --env -ERW --allow-run webcam.ts",
     "build-live": "deno compile --env -ERW --allow-run webcam-live.ts",
     "run": "deno run --env -ERW --allow-run webcam.ts",
-    "live": "deno run --env -ERW --allow-run webcam-live.ts"
+    "live": "deno run --env -ERW --allow-run webcam-live.ts",
+    "brightness": "deno run --env -ERW --allow-run webcam-brightness.ts"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,5 @@
 {
   "imports": {
-    "run_simple": "https://deno.land/x/run_simple@2.3.0/mod.ts",
     "@std/log": "https://deno.land/std@0.222.1/log/mod.ts"
   },
   "tasks": {

--- a/deno.lock
+++ b/deno.lock
@@ -2,89 +2,20 @@
   "version": "3",
   "packages": {
     "specifiers": {
-      "jsr:@oak/commons@^1.0": "jsr:@oak/commons@1.0.0",
       "jsr:@std/assert": "jsr:@std/assert@1.0.5",
-      "jsr:@std/assert@^1.0": "jsr:@std/assert@1.0.5",
       "jsr:@std/assert@^1.0.4": "jsr:@std/assert@1.0.5",
-      "jsr:@std/bytes@^1.0": "jsr:@std/bytes@1.0.2",
-      "jsr:@std/bytes@^1.0.2": "jsr:@std/bytes@1.0.2",
-      "jsr:@std/crypto@^1.0": "jsr:@std/crypto@1.0.3",
-      "jsr:@std/encoding@^1.0": "jsr:@std/encoding@1.0.5",
-      "jsr:@std/encoding@^1.0.5": "jsr:@std/encoding@1.0.5",
-      "jsr:@std/fmt@^0.224.0": "jsr:@std/fmt@0.224.0",
-      "jsr:@std/http@^1.0": "jsr:@std/http@1.0.6",
-      "jsr:@std/internal@^0.224.0": "jsr:@std/internal@0.224.0",
       "jsr:@std/internal@^1.0.3": "jsr:@std/internal@1.0.3",
-      "jsr:@std/io@0.224": "jsr:@std/io@0.224.8",
-      "jsr:@std/media-types@^1.0": "jsr:@std/media-types@1.0.3",
-      "jsr:@std/path@^1.0": "jsr:@std/path@1.0.5",
-      "jsr:@std/testing": "jsr:@std/testing@1.0.2",
-      "npm:@types/node": "npm:@types/node@18.16.19",
-      "npm:path-to-regexp@6.2.1": "npm:path-to-regexp@6.2.1"
+      "jsr:@std/testing": "jsr:@std/testing@1.0.2"
     },
     "jsr": {
-      "@oak/commons@1.0.0": {
-        "integrity": "49805b55603c3627a9d6235c0655aa2b6222d3036b3a13ff0380c16368f607ac",
-        "dependencies": [
-          "jsr:@std/assert@^1.0",
-          "jsr:@std/bytes@^1.0",
-          "jsr:@std/crypto@^1.0",
-          "jsr:@std/encoding@^1.0",
-          "jsr:@std/http@^1.0",
-          "jsr:@std/media-types@^1.0"
-        ]
-      },
-      "@std/assert@0.224.0": {
-        "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f",
-        "dependencies": [
-          "jsr:@std/fmt@^0.224.0",
-          "jsr:@std/internal@^0.224.0"
-        ]
-      },
       "@std/assert@1.0.5": {
         "integrity": "e37da8e4033490ce613eec4ac1d78dba1faf5b02a3f6c573a28f15365b9b440f",
         "dependencies": [
           "jsr:@std/internal@^1.0.3"
         ]
       },
-      "@std/bytes@1.0.2": {
-        "integrity": "fbdee322bbd8c599a6af186a1603b3355e59a5fb1baa139f8f4c3c9a1b3e3d57"
-      },
-      "@std/crypto@1.0.3": {
-        "integrity": "a2a32f51ddef632d299e3879cd027c630dcd4d1d9a5285d6e6788072f4e51e7f"
-      },
-      "@std/encoding@1.0.5": {
-        "integrity": "ecf363d4fc25bd85bd915ff6733a7e79b67e0e7806334af15f4645c569fefc04"
-      },
-      "@std/fmt@0.224.0": {
-        "integrity": "e20e9a2312a8b5393272c26191c0a68eda8d2c4b08b046bad1673148f1d69851"
-      },
-      "@std/http@1.0.6": {
-        "integrity": "20a6f3fa4a914fbb19ea96572f2519b656232597092581ed706cd865d842d0d0",
-        "dependencies": [
-          "jsr:@std/encoding@^1.0.5"
-        ]
-      },
-      "@std/internal@0.224.0": {
-        "integrity": "afc50644f9cdf4495eeb80523a8f6d27226b4b36c45c7c195dfccad4b8509291",
-        "dependencies": [
-          "jsr:@std/fmt@^0.224.0"
-        ]
-      },
       "@std/internal@1.0.3": {
         "integrity": "208e9b94a3d5649bd880e9ca38b885ab7651ab5b5303a56ed25de4755fb7b11e"
-      },
-      "@std/io@0.224.8": {
-        "integrity": "f525d05d51fd873de6352b9afcf35cab9ab5dc448bf3c20e0c8b521ded9be392",
-        "dependencies": [
-          "jsr:@std/bytes@^1.0.2"
-        ]
-      },
-      "@std/media-types@1.0.3": {
-        "integrity": "b12d30a7852f7578f4d210622df713bbfd1cbdd9b4ec2eaf5c1845ab70bab159"
-      },
-      "@std/path@1.0.5": {
-        "integrity": "846edda0b1811e6986bbad4a51a14556be52827bbe6df4ff5e4446301ea248e0"
       },
       "@std/testing@1.0.2": {
         "integrity": "9e8a7f4e26c219addabe7942d09c3450fa0a74e9662341961bc0ef502274dec3",
@@ -92,28 +23,11 @@
           "jsr:@std/assert@^1.0.4"
         ]
       }
-    },
-    "npm": {
-      "@types/node@18.16.19": {
-        "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
-        "dependencies": {}
-      },
-      "path-to-regexp@6.2.1": {
-        "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-        "dependencies": {}
-      }
     }
-  },
-  "redirects": {
-    "https://deno.land/std/testing/asserts.ts": "https://deno.land/std@0.224.0/testing/asserts.ts",
-    "https://deno.land/x/oak/mod.ts": "https://deno.land/x/oak@v17.0.0/mod.ts"
   },
   "remote": {
     "https://deno.land/std@0.222.1/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
     "https://deno.land/std@0.222.1/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
-    "https://deno.land/std@0.222.1/dotenv/mod.ts": "0180eaeedaaf88647318811cdaa418cc64dc51fb08354f91f5f480d0a1309f7d",
-    "https://deno.land/std@0.222.1/dotenv/parse.ts": "09977ff88dfd1f24f9973a338f0f91bbdb9307eb5ff6085446e7c423e4c7ba0c",
-    "https://deno.land/std@0.222.1/dotenv/stringify.ts": "275da322c409170160440836342eaa7cf012a1d11a7e700d8ca4e7f2f8aa4615",
     "https://deno.land/std@0.222.1/fmt/colors.ts": "d239d84620b921ea520125d778947881f62c50e78deef2657073840b8af9559a",
     "https://deno.land/std@0.222.1/fs/exists.ts": "3d38cb7dcbca3cf313be343a7b8af18a87bddb4b5ca1bd2314be12d06533b50f",
     "https://deno.land/std@0.222.1/io/types.ts": "acecb3074c730b5ff487ba4fe9ce51e67bd982aa07c95e5f5679b7b2f24ad129",
@@ -134,72 +48,6 @@
     "https://deno.land/std@0.222.1/log/mod.ts": "650c53c2c5d9eb05210c4ec54184ecb5bd24fb32ce28e65fad039853978f53f3",
     "https://deno.land/std@0.222.1/log/rotating_file_handler.ts": "a6e7c712e568b618303273ff95483f6ab86dec0a485c73c2e399765f752b5aa8",
     "https://deno.land/std@0.222.1/log/setup.ts": "42425c550da52c7def7f63a4fcc1ac01a4aec6c73336697a640978d6a324e7a6",
-    "https://deno.land/std@0.222.1/log/warn.ts": "f1a6bc33a481f231a0257e6d66e26c2e695b931d5e917d8de4f2b825778dfd4e",
-    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
-    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
-    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
-    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
-    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
-    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
-    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
-    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
-    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
-    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
-    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
-    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
-    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
-    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
-    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
-    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
-    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
-    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
-    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
-    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
-    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
-    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
-    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
-    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
-    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
-    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
-    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
-    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
-    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
-    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
-    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
-    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
-    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e",
-    "https://deno.land/std@0.224.0/testing/asserts.ts": "d0cdbabadc49cc4247a50732ee0df1403fdcd0f95360294ad448ae8c240f3f5c",
-    "https://deno.land/x/oak@v17.0.0/application.ts": "f6b48422d3207a4cfbd4f535fd54999dc41e33a42e08447fe166fac8c0d07067",
-    "https://deno.land/x/oak@v17.0.0/body.ts": "f84e31e923fdadc3463519a4ab5409083d00281ae4cae00b9594af3e808f3007",
-    "https://deno.land/x/oak@v17.0.0/context.ts": "345cfdaa5a2310558ee0863f2fba5f9ba648188412b16ce342c33266c085f5d3",
-    "https://deno.land/x/oak@v17.0.0/deps.ts": "b778c76e91d6d2afe6124981212b6dc3d0b195739ea01857a45396dc78812b59",
-    "https://deno.land/x/oak@v17.0.0/http_server_bun.ts": "cb3a66c735cd0533c4c3776b37ae627ab42344c82f91dff63e3030d9656fd3a0",
-    "https://deno.land/x/oak@v17.0.0/http_server_native.ts": "3bea00ebb9638203d2449fbf9a14a6b87f119bd45012f13282ececdf7b4c4242",
-    "https://deno.land/x/oak@v17.0.0/http_server_native_request.ts": "a4da6f4939736e6323720db2d4b0d19ff2e83f02e52ab1eea9ae80f2c047fa56",
-    "https://deno.land/x/oak@v17.0.0/http_server_node.ts": "9bb5291c15305b297fd634aa4c6b1d5054368f4b7a171d7c7c302c73eb2489ed",
-    "https://deno.land/x/oak@v17.0.0/middleware.ts": "4170180fe5009d2581a0bdc995e5953b90ccb5b1c3767f3eae8a4fe238b8bd81",
-    "https://deno.land/x/oak@v17.0.0/middleware/etag.ts": "34a31c3d1c0cafcf331361cc54a882e5c6efe5757e9ab9bad3b83412c31431bc",
-    "https://deno.land/x/oak@v17.0.0/middleware/proxy.ts": "a0b4964509d4320735ffbe52ae2629c78e302dd9b934fcf2ddf189d491469892",
-    "https://deno.land/x/oak@v17.0.0/middleware/serve.ts": "efceebd70afb73bcabe0a6a8981f3d8474a2f2f30e85b46761aee49e81bd9d6a",
-    "https://deno.land/x/oak@v17.0.0/mod.ts": "38e53e01e609583e843f3e2b2677de9872d23d68939ce0de85b402e7a8db01a7",
-    "https://deno.land/x/oak@v17.0.0/node_shims.ts": "4db1569b2b79b73f37c4d947f4aaa50a93e266d48fe67601c8a31af17a28884d",
-    "https://deno.land/x/oak@v17.0.0/request.ts": "1e7f2c338cd6889b616bbdc9e2062eac27acbffde05c685adfb1c60ecc80682a",
-    "https://deno.land/x/oak@v17.0.0/response.ts": "bc47174d3d797ffc802f40fba006c16de8390e776a36f6f4a4d4f58b278bf36f",
-    "https://deno.land/x/oak@v17.0.0/router.ts": "882f36a576e280b0d617cc174feca320f02deed77bdea8264444ba8b55cc0422",
-    "https://deno.land/x/oak@v17.0.0/send.ts": "a207e48ff384bf9713edfe4d1e35a89800c349b9b622d38a1f5512fd5b79e745",
-    "https://deno.land/x/oak@v17.0.0/testing.ts": "2b80f231aa2207ecdee690da46e230d1e5375d95b268dfaa5205b2b2f6cc740f",
-    "https://deno.land/x/oak@v17.0.0/types.ts": "cd4ccd3e182d0cba2117cd27f560267970470ab9c0ff6556cadd73f605193be7",
-    "https://deno.land/x/oak@v17.0.0/utils/clone_state.ts": "cf8989ddd56816b36ada253ae0acdbd46cdf3d68dbe674d2b66c46640fab3500",
-    "https://deno.land/x/oak@v17.0.0/utils/consts.ts": "137c4f73479f5e98a13153b9305f06f0d85df3cf2aacad2c9f82d4c1f3a2f105",
-    "https://deno.land/x/oak@v17.0.0/utils/create_promise_with_resolvers.ts": "de99e9a998162b929a011f8873eaf0895cf4742492b3ce6f6866d39217342523",
-    "https://deno.land/x/oak@v17.0.0/utils/decode_component.ts": "d3e2c40ecdd2fdb79761c6e9ae224cf01a4643f7c5f4c1e0b69698d43025261b",
-    "https://deno.land/x/oak@v17.0.0/utils/encode_url.ts": "c0ed6b318eb9523adeebba32eb9acd059c0f94d3511b2b9e3b024722d1b3dfb8",
-    "https://deno.land/x/oak@v17.0.0/utils/resolve_path.ts": "aa39d54a003b38fee55f340a0cba3f93a7af85b8ddd5fbfb049a98fc0109b36d",
-    "https://deno.land/x/oak@v17.0.0/utils/streams.ts": "6d55543fdeddc3c9c6f512de227b9b33ff4b0ec5e320edc109f0cbf9bef8963f",
-    "https://deno.land/x/oak@v17.0.0/utils/type_guards.ts": "a1b42aa4c431c4c07d3f8a45a2142020f86d5a3e1e319af94fdf2f4c6c72465f",
-    "https://deno.land/x/run_simple@2.3.0/mod.ts": "a8b8965264d093a0799db970379a746e5e336d74f10a1681250dfeb2c6077721",
-    "https://deno.land/x/run_simple@2.3.0/src/fn.ts": "8e5f2cf8d95b07dd6086d81bd188b2d82ebbcb8ae27799945a5560d0154c58ef",
-    "https://deno.land/x/run_simple@2.3.0/src/os.ts": "47820a9a43f99006ef8e6a0c4c353406cda1155e18b6ced50d0863c2a11863e9",
-    "https://deno.land/x/run_simple@2.3.0/src/run.ts": "95f3ae42d2b2e18cfdf4e11d01745bfa68e4ec38eff6f7c1890065bcf5db6c2d"
+    "https://deno.land/std@0.222.1/log/warn.ts": "f1a6bc33a481f231a0257e6d66e26c2e695b931d5e917d8de4f2b825778dfd4e"
   }
 }

--- a/lib/brightness.test.ts
+++ b/lib/brightness.test.ts
@@ -1,29 +1,35 @@
 import { assertSpyCall, assertSpyCalls, stub } from "jsr:@std/testing/mock";
-import { takeSnapshot } from "./snapshot.ts";
+import { calcBrightness } from "./brightness.ts";
 import { mockRun } from "../__mocks/mocks.ts";
 
 Deno.test("takeSnapshot calls run with correct arguments", async () => {
-  const snapshotPath = "/path/to/snapshot.jpg";
   const mockEnv = stub(Deno.env, "get", () => "snapshot");
 
-  await takeSnapshot(mockRun, snapshotPath);
+  await calcBrightness(mockRun, 0.5);
 
   assertSpyCalls(mockRun, 1);
   assertSpyCall(mockRun, 0, {
     args: [
       [
         "snapshot",
-        "-o",
-        snapshotPath,
         "--immediate",
         "--width",
-        "2664",
+        "800",
         "--height",
-        "1980",
+        "600",
         "--shutter",
-        "60000",
-        "--gain",
-        "1.5",
+        "50000",
+        "-o",
+        "-",
+      ],
+      [
+        "snapshot",
+        "jpeg:-",
+        "-colorspace",
+        "Gray",
+        "-format",
+        "%[fx:quantumrange*mean]",
+        "info:",
       ],
     ],
   });

--- a/lib/brightness.ts
+++ b/lib/brightness.ts
@@ -1,0 +1,86 @@
+import { env } from "./utils.ts";
+
+export const calcBrightness = async (
+  brightness: number,
+) => {
+  const libcameraArgs = [
+    env("SNAPSHOT_CMD"),
+    "--immediate",
+    "--width",
+    "800",
+    "--height",
+    "600",
+    "--shutter",
+    "50000",
+    "-o",
+    "-", // Output to stdout
+  ];
+
+  const convertArgs = [
+    env("CONVERT_CMD"),
+    "jpeg:-", // Read from stdin
+    "-colorspace",
+    "Gray",
+    "-format",
+    "%[fx:quantumrange*mean]",
+    "info:",
+  ];
+
+  const brightnessValue = await runPipedCommands(libcameraArgs, convertArgs);
+  const brightnessNumber = parseFloat(brightnessValue);
+  return calculateShutterSpeed(brightnessNumber, brightness).toString();
+};
+
+async function runPipedCommands(
+  cmd1: string[],
+  cmd2?: string[],
+): Promise<string> {
+  // Create first process that writes to stdout
+  const p1 = new Deno.Command(cmd1[0], {
+    args: cmd1.slice(1),
+    stdout: "piped",
+  });
+
+  // Start the first process
+  const proc1 = p1.spawn();
+
+  if (cmd2) {
+    // Create second process that reads from stdin
+    const p2 = new Deno.Command(cmd2[0], {
+      args: cmd2.slice(1),
+      stdin: "piped",
+      stdout: "piped",
+    });
+
+    // Start the second process
+    const proc2 = p2.spawn();
+
+    // Pipe output from proc1 to proc2
+    await proc1.stdout.pipeTo(proc2.stdin);
+
+    // Get final output from proc2
+    const { stdout } = await proc2.output();
+    return new TextDecoder().decode(stdout);
+  } else {
+    // Get final output from proc1 if cmd2 is not provided
+    const { stdout } = await proc1.output();
+    return new TextDecoder().decode(stdout);
+  }
+}
+
+/**
+ * Calculates optimal shutter speed based on measured brightness
+ * @param {number} brightness - The measured brightness value from imagemagick
+ * @param {number} adjustment - Adjustment factor (default 1.0, higher = brighter)
+ * @returns {number} Shutter speed in microseconds (constrained between 100-100000)
+ */
+function calculateShutterSpeed(brightness: number, adjustment = 1.0) {
+  // Base calculation - inverse relationship between brightness and shutter
+  const baseShutter = (65535 / brightness) * 50000;
+
+  // Apply adjustment factor
+  const adjustedShutter = baseShutter * adjustment;
+
+  // Constrain between 100μs (1/10000s) and 100000μs (1/10s)
+  return Math.round(Math.min(Math.max(adjustedShutter, 100), 100000));
+}

--- a/lib/brightness.ts
+++ b/lib/brightness.ts
@@ -1,6 +1,7 @@
-import { env } from "./utils.ts";
+import { calculateShutterSpeed, env } from "./utils.ts";
 
 export const calcBrightness = async (
+  run: (cmd1: string[], cmd2?: string[]) => Promise<string>,
   brightness: number,
 ) => {
   const libcameraArgs = [
@@ -26,61 +27,10 @@ export const calcBrightness = async (
     "info:",
   ];
 
-  const brightnessValue = await runPipedCommands(libcameraArgs, convertArgs);
+  const brightnessValue = await run(libcameraArgs, convertArgs);
   const brightnessNumber = parseFloat(brightnessValue);
-  return calculateShutterSpeed(brightnessNumber, brightness).toString();
+  const shutterSpeed = calculateShutterSpeed(brightnessNumber, brightness)
+    .toString();
+
+  return `${brightnessValue}:${shutterSpeed}`;
 };
-
-async function runPipedCommands(
-  cmd1: string[],
-  cmd2?: string[],
-): Promise<string> {
-  // Create first process that writes to stdout
-  const p1 = new Deno.Command(cmd1[0], {
-    args: cmd1.slice(1),
-    stdout: "piped",
-  });
-
-  // Start the first process
-  const proc1 = p1.spawn();
-
-  if (cmd2) {
-    // Create second process that reads from stdin
-    const p2 = new Deno.Command(cmd2[0], {
-      args: cmd2.slice(1),
-      stdin: "piped",
-      stdout: "piped",
-    });
-
-    // Start the second process
-    const proc2 = p2.spawn();
-
-    // Pipe output from proc1 to proc2
-    await proc1.stdout.pipeTo(proc2.stdin);
-
-    // Get final output from proc2
-    const { stdout } = await proc2.output();
-    return new TextDecoder().decode(stdout);
-  } else {
-    // Get final output from proc1 if cmd2 is not provided
-    const { stdout } = await proc1.output();
-    return new TextDecoder().decode(stdout);
-  }
-}
-
-/**
- * Calculates optimal shutter speed based on measured brightness
- * @param {number} brightness - The measured brightness value from imagemagick
- * @param {number} adjustment - Adjustment factor (default 1.0, higher = brighter)
- * @returns {number} Shutter speed in microseconds (constrained between 100-100000)
- */
-function calculateShutterSpeed(brightness: number, adjustment = 1.0) {
-  // Base calculation - inverse relationship between brightness and shutter
-  const baseShutter = (65535 / brightness) * 50000;
-
-  // Apply adjustment factor
-  const adjustedShutter = baseShutter * adjustment;
-
-  // Constrain between 100μs (1/10000s) and 100000μs (1/10s)
-  return Math.round(Math.min(Math.max(adjustedShutter, 100), 100000));
-}

--- a/lib/process.ts
+++ b/lib/process.ts
@@ -9,7 +9,7 @@ import { env } from "./utils.ts";
  * @returns A Promise that resolves when the snapshot processing is complete.
  */
 export const processSnapshot = async (
-  run: (args: string[]) => Promise<string>,
+  run: (cmd1: string[], cmd2?: string[]) => Promise<string>,
   snapshotPath: string,
   iso: string,
 ) => {

--- a/lib/snapshot.ts
+++ b/lib/snapshot.ts
@@ -1,17 +1,11 @@
 import { env } from "./utils.ts";
 
-/**
- * Takes a snapshot using the specified `run` function and saves it to the given `snapshotPath`.
- *
- * @param run - A function that takes an array of string arguments and returns a promise that resolves to a string.
- * @param snapshotPath - The path where the snapshot will be saved.
- * @returns A promise that resolves when the snapshot is taken.
- */
 export const takeSnapshot = async (
   run: (args: string[]) => Promise<string>,
   snapshotPath: string,
+  shutterSpeed?: string,
 ) => {
-  await run([
+  return await run([
     env("SNAPSHOT_CMD"),
     "-o",
     snapshotPath,
@@ -20,7 +14,9 @@ export const takeSnapshot = async (
     "2664",
     "--height",
     "1980",
+    "--shutter",
+    shutterSpeed || "60000",
     "--gain",
-    "1.6",
+    "1.5",
   ]);
 };

--- a/lib/snapshot.ts
+++ b/lib/snapshot.ts
@@ -1,11 +1,11 @@
 import { env } from "./utils.ts";
 
 export const takeSnapshot = async (
-  run: (args: string[]) => Promise<string>,
+  run: (cmd1: string[], cmd2?: string[]) => Promise<string>,
   snapshotPath: string,
   shutterSpeed?: string,
 ) => {
-  return await run([
+  const libcameraArgs = [
     env("SNAPSHOT_CMD"),
     "-o",
     snapshotPath,
@@ -18,5 +18,7 @@ export const takeSnapshot = async (
     shutterSpeed || "60000",
     "--gain",
     "1.5",
-  ]);
+  ];
+
+  return await run(libcameraArgs);
 };

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -7,7 +7,7 @@ import { env } from "./utils.ts";
  * @returns A promise that resolves when the synchronization is complete.
  */
 export const syncSnapshot = async (
-  run: (args: string[]) => Promise<string>,
+  run: (cmd1: string[], cmd2?: string[]) => Promise<string>,
   imagePath: string,
 ) => {
   await run([

--- a/lib/time-lapse.ts
+++ b/lib/time-lapse.ts
@@ -1,7 +1,7 @@
 import { env } from "./utils.ts";
 
 export const createTimeLapseVideo = async (
-  run: (args: string[]) => Promise<string>,
+  run: (cmd1: string[], cmd2?: string[]) => Promise<string>,
   videoImagesPath: string,
   videoPath: string,
 ) => {

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "jsr:@std/assert";
-import { env, getFormattedDate } from "./utils.ts";
+import { calculateShutterSpeed, env, getFormattedDate } from "./utils.ts";
 
 Deno.test("getFormattedDate returns correct dateString and iso", () => {
   // Save the original Date constructor
@@ -47,4 +47,15 @@ Deno.test("env returns the correct environment variable value", () => {
     // Restore the original Deno.env.get
     Deno.env.get = originalEnvGet;
   }
+});
+
+Deno.test("calculateShutterSpeed", () => {
+  // the results in the assertions is the value passed to --shutter
+  assertEquals(calculateShutterSpeed(89285.1), 36700);
+  assertEquals(calculateShutterSpeed(59285.1), 55271);
+  assertEquals(calculateShutterSpeed(49285.1), 66486);
+  assertEquals(calculateShutterSpeed(29285.1), 111891);
+  assertEquals(calculateShutterSpeed(29206.5), 112192);
+  assertEquals(calculateShutterSpeed(29149.4), 112412);
+  assertEquals(calculateShutterSpeed(1234.3), 200000);
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -19,22 +19,15 @@ export const getFormattedDate = () => {
   return { dateString: iso.slice(0, 10), iso };
 };
 
-/**
- * Executes a given action with logging and handles any errors that occur.
- *
- * @param action - The action to be executed.
- * @param successMessage - The success message to be logged if the action is successful.
- * @param errorMessage - The error message to be logged if the action fails.
- * @returns A promise that resolves when the action is completed.
- */
 export async function executeWithLogging(
-  action: () => Promise<void>,
+  action: () => Promise<string | void>,
   successMessage: string,
   errorMessage: string,
 ) {
   try {
-    await action();
+    const result = await action();
     log.info(successMessage);
+    return result;
   } catch (e) {
     log.error(errorMessage, e.message);
   }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -32,3 +32,66 @@ export async function executeWithLogging(
     log.error(errorMessage, e.message);
   }
 }
+
+/**
+ * Calculates optimal shutter speed based on measured brightness
+ * @param {number} brightness - The measured brightness value from imagemagick
+ * @param {number} adjustment - Adjustment factor (default 1.0, higher = brighter)
+ * @returns {number} Shutter speed in microseconds (constrained between 100-100000)
+ */
+export function calculateShutterSpeed(brightness: number, adjustment = 1.0) {
+  // Base calculation - inverse relationship between brightness and shutter
+  const baseShutter = (65535 / brightness) * 50000;
+
+  // Apply adjustment factor
+  const adjustedShutter = baseShutter * adjustment;
+
+  // Constrain between 100μs (1/10000s) and 200000μs (1/10s)
+  return Math.round(Math.min(Math.max(adjustedShutter, 100), 200000));
+}
+
+/**
+ * Executes two commands in a piped manner, where the output of the first command
+ * is used as the input for the second command. If the second command is not provided,
+ * it simply returns the output of the first command.
+ *
+ * @param cmd1 - The first command to execute, represented as an array of strings where the first element is the command and the rest are the arguments.
+ * @param cmd2 - (Optional) The second command to execute, represented as an array of strings where the first element is the command and the rest are the arguments.
+ * @returns A promise that resolves to the final output of the executed commands as a string.
+ */
+export async function runPipedCommands(
+  cmd1: string[],
+  cmd2?: string[],
+): Promise<string> {
+  // Create first process that writes to stdout
+  const p1 = new Deno.Command(cmd1[0], {
+    args: cmd1.slice(1),
+    stdout: "piped",
+  });
+
+  // Start the first process
+  const proc1 = p1.spawn();
+
+  if (cmd2) {
+    // Create second process that reads from stdin
+    const p2 = new Deno.Command(cmd2[0], {
+      args: cmd2.slice(1),
+      stdin: "piped",
+      stdout: "piped",
+    });
+
+    // Start the second process
+    const proc2 = p2.spawn();
+
+    // Pipe output from proc1 to proc2
+    await proc1.stdout.pipeTo(proc2.stdin);
+
+    // Get final output from proc2
+    const { stdout } = await proc2.output();
+    return new TextDecoder().decode(stdout);
+  } else {
+    // Get final output from proc1 if cmd2 is not provided
+    const { stdout } = await proc1.output();
+    return new TextDecoder().decode(stdout);
+  }
+}

--- a/webcam-brightness.ts
+++ b/webcam-brightness.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env -S deno run --allow-run --allow-read --allow-write
+
+import { run } from "run_simple";
+import { calcBrightness } from "./lib/brightness.ts";
+import { takeSnapshot } from "./lib/snapshot.ts";
+import { executeWithLogging } from "./lib/utils.ts";
+
+const runCheck = async () => {
+  const shutterSpeed = await executeWithLogging(
+    () => calcBrightness(0.7),
+    "Brightness found",
+    "Brightness check failed!",
+  ) as string;
+
+  await executeWithLogging(
+    () => takeSnapshot(run, "brightness.jpg", shutterSpeed),
+    `Snapshot taken with --shutter ${shutterSpeed}`,
+    "Brightness check failed!",
+  );
+};
+
+runCheck();

--- a/webcam-brightness.ts
+++ b/webcam-brightness.ts
@@ -1,20 +1,21 @@
 #!/usr/bin/env -S deno run --allow-run --allow-read --allow-write
 
-import { run } from "run_simple";
 import { calcBrightness } from "./lib/brightness.ts";
 import { takeSnapshot } from "./lib/snapshot.ts";
-import { executeWithLogging } from "./lib/utils.ts";
+import { executeWithLogging, runPipedCommands } from "./lib/utils.ts";
 
 const runCheck = async () => {
-  const shutterSpeed = await executeWithLogging(
-    () => calcBrightness(0.7),
+  const results = await executeWithLogging(
+    () => calcBrightness(runPipedCommands, 1.0),
     "Brightness found",
     "Brightness check failed!",
   ) as string;
 
+  const [brightness, shutterSpeed] = results.split(":");
+
   await executeWithLogging(
-    () => takeSnapshot(run, "brightness.jpg", shutterSpeed),
-    `Snapshot taken with --shutter ${shutterSpeed}`,
+    () => takeSnapshot(runPipedCommands, "brightness.jpg", shutterSpeed),
+    `Snapshot taken with --shutter ${shutterSpeed} for brightness ${brightness}`,
     "Brightness check failed!",
   );
 };

--- a/webcam-live.ts
+++ b/webcam-live.ts
@@ -1,23 +1,35 @@
 #!/usr/bin/env -S deno run --allow-run --allow-read --allow-write
 
-import { run } from "run_simple";
 import { takeSnapshot } from "./lib/snapshot.ts";
 import { processSnapshot } from "./lib/process.ts";
 import { syncSnapshot } from "./lib/sync.ts";
-import { executeWithLogging, getFormattedDate } from "./lib/utils.ts";
+import {
+  executeWithLogging,
+  getFormattedDate,
+  runPipedCommands,
+} from "./lib/utils.ts";
 import { paths } from "./lib/config.ts";
+import { calcBrightness } from "./lib/brightness.ts";
 
 const runCameraCapture = async () => {
   const { iso } = getFormattedDate();
 
+  const results = await executeWithLogging(
+    () => calcBrightness(runPipedCommands, 1.0),
+    "Brightness found",
+    "Brightness check failed!",
+  ) as string;
+
+  const [brightness, shutterSpeed] = results.split(":");
+
   await executeWithLogging(
-    () => takeSnapshot(run, paths.liveshotPath),
-    `Snapshot taken: ${paths.liveshotPath}`,
+    () => takeSnapshot(runPipedCommands, paths.liveshotPath, shutterSpeed),
+    `Snapshot taken: ${paths.liveshotPath} with --shutter ${shutterSpeed} for brightness ${brightness}`,
     `Snapshot [${iso}] failed!`,
   );
 
   await executeWithLogging(
-    () => processSnapshot(run, paths.liveshotPath, iso),
+    () => processSnapshot(runPipedCommands, paths.liveshotPath, iso),
     `Snapshot processed: ${paths.liveshotPath}`,
     `Snapshot [${iso}] processing failed!`,
   );
@@ -29,7 +41,7 @@ const runCameraCapture = async () => {
   );
 
   await executeWithLogging(
-    () => syncSnapshot(run, paths.imagesDir),
+    () => syncSnapshot(runPipedCommands, paths.imagesDir),
     `Files synced with S3`,
     `Error syncing with S3`,
   );

--- a/webcam.ts
+++ b/webcam.ts
@@ -1,24 +1,36 @@
 #!/usr/bin/env -S deno run --allow-run --allow-read --allow-write
 
-import { run } from "run_simple";
 import { takeSnapshot } from "./lib/snapshot.ts";
 import { processSnapshot } from "./lib/process.ts";
 import { syncSnapshot } from "./lib/sync.ts";
 // import { createTimeLapseVideo } from "./lib/time-lapse.ts";
-import { executeWithLogging, getFormattedDate } from "./lib/utils.ts";
+import {
+  executeWithLogging,
+  getFormattedDate,
+  runPipedCommands,
+} from "./lib/utils.ts";
 import { paths } from "./lib/config.ts";
+import { calcBrightness } from "./lib/brightness.ts";
 
 const runCameraCapture = async () => {
   const { iso } = getFormattedDate();
 
+  const results = await executeWithLogging(
+    () => calcBrightness(runPipedCommands, 1.0),
+    "Brightness found",
+    "Brightness check failed!",
+  ) as string;
+
+  const [brightness, shutterSpeed] = results.split(":");
+
   await executeWithLogging(
-    () => takeSnapshot(run, paths.snapshotPath),
-    `Snapshot taken: ${paths.snapshotPath}`,
+    () => takeSnapshot(runPipedCommands, paths.snapshotPath, shutterSpeed),
+    `Snapshot taken: ${paths.snapshotPath} with --shutter ${shutterSpeed} for brightness ${brightness}`,
     `Snapshot [${iso}] failed!`,
   );
 
   await executeWithLogging(
-    () => processSnapshot(run, paths.snapshotPath, iso),
+    () => processSnapshot(runPipedCommands, paths.snapshotPath, iso),
     `Snapshot processed: ${paths.snapshotPath}`,
     `Snapshot [${iso}] processing failed!`,
   );
@@ -30,7 +42,7 @@ const runCameraCapture = async () => {
   );
 
   await executeWithLogging(
-    () => syncSnapshot(run, paths.imagesDir),
+    () => syncSnapshot(runPipedCommands, paths.imagesDir),
     `Files synced with S3`,
     `Error syncing with S3`,
   );
@@ -44,7 +56,7 @@ const runCameraCapture = async () => {
   // Uncomment to create timelapse video on device
   //
   // await executeWithLogging(
-  //   () => createTimeLapseVideo(run, paths.videoImagesPath, paths.videoPath),
+  //   () => createTimeLapseVideo(runPipedCommands, paths.videoImagesPath, paths.videoPath),
   //   `Time-lapse video updated: ${paths.videoPath}`,
   //   `Time-lapse video update failed!`,
   // );


### PR DESCRIPTION
This pull request introduces a new feature to adjust the brightness of snapshots taken by the webcam. It includes changes to several files to support this new functionality. The most important changes are grouped by their themes below:

### New Brightness Adjustment Feature:

* Added a new script `webcam-brightness.ts` to calculate brightness and take snapshots accordingly.
* Created a new module `lib/brightness.ts` that includes the `calcBrightness` function for calculating optimal brightness and shutter speed.

### Modifications to Existing Functionality:

* Updated `lib/snapshot.ts` to include an optional `shutterSpeed` parameter in the `takeSnapshot` function, allowing snapshots to be taken with the calculated shutter speed. [[1]](diffhunk://#diff-334ec0a733157f2e2ad259ec3cb234bd758b7a9b915cc09fee6bc22b13860eedL3-R8) [[2]](diffhunk://#diff-334ec0a733157f2e2ad259ec3cb234bd758b7a9b915cc09fee6bc22b13860eedR17-R20)
* Modified the `executeWithLogging` function in `lib/utils.ts` to handle and return results from actions.

### Configuration Changes:

* Updated `deno.json` to include a new script command `brightness` for running the brightness adjustment script.